### PR TITLE
Fixed Flaky Tes ```When findAllNonMatchingScalaVersionDependenciesWithCounterparts given…```

### DIFF
--- a/src/main/groovy/com/github/prokod/gradle/crossbuild/utils/DependencyInsights.groovy
+++ b/src/main/groovy/com/github/prokod/gradle/crossbuild/utils/DependencyInsights.groovy
@@ -347,7 +347,7 @@ class DependencyInsights {
         def dependenciesView = nonMatchingDependencyInsights.collect { nonMatchingDependencyInsight ->
             def matchingDepTupleSet = dependencies.collect { dep ->
                 DependencyInsight.parse(dep, scalaVersions)
-            }.findAll { dependencyInsightPredicate(it, nonMatchingDependencyInsight, scalaVersion) }.collect().toSet()
+            }.findAll { dependencyInsightPredicate(it, nonMatchingDependencyInsight, scalaVersion) }.collect { it } as LinkedHashSet
             new Tuple2(nonMatchingDependencyInsight, matchingDepTupleSet)
         }
 


### PR DESCRIPTION
## Changes proposed
Test```"When findAllNonMatchingScalaVersionDependenciesWithCounterparts given a dependency set it should return correctly"``` was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown by: ```tuplesList[1].second[1].dependency == dep31```. The flakiness was resulted from the random order of the elements stored in the HashSets as the values of ```tupleList```. The expected values used in the unit test was defined using strings with fixed order, and it will not match the elements inside the regular HashSet during shuffling; thus, the test will fail. The error messages:
```
com.github.prokod.gradle.crossbuild.utils.DependencyInsightsTest > When findAllNonMatchingScalaVersionDependenciesWithCounterparts given a dependency set it should return correctly FAILED
    Condition not satisfied:

    tuplesList[1].second[1].dependency == dep31
    |         |   |     |   |          |  |
    |         |   |     |   |          |  DefaultExternalModuleDependency{group='some.group', name='somescalalib_2.10', version='1.2.6', configuration='default'}
    |         |   |     |   |          false
    |         |   |     |   DefaultExternalModuleDependency{group='some.group', name='somescalalib_2.10', version='1.2.5', configuration='default'}
    |         |   |     <com.github.prokod.gradle.crossbuild.model.DependencyInsight@d24df2d1 dependency=DefaultExternalModuleDependency{group='some.group', name='somescalalib_2.10', version='1.2.5', configuration='default'} group=some.group version=1.2.5 baseName=somescalalib appendix=null supposedScalaVersion=2.10>
    |         |   [com.github.prokod.gradle.crossbuild.model.DependencyInsight@d24df2d1, com.github.prokod.gradle.crossbuild.model.DependencyInsight@d24df30c]
    |         [com.github.prokod.gradle.crossbuild.model.DependencyInsight@d236857a, [com.github.prokod.gradle.crossbuild.model.DependencyInsight@d24df2d1, com.github.prokod.gradle.crossbuild.model.DependencyInsight@d24df30c]]
    [[com.github.prokod.gradle.crossbuild.model.DependencyInsight@d24df25c, [com.github.prokod.gradle.crossbuild.model.DependencyInsight@d24df2d1, com.github.prokod.gradle.crossbuild.model.DependencyInsight@d24df30c]], [com.github.prokod.gradle.crossbuild.model.DependencyInsight@d236857a, [com.github.prokod.gradle.crossbuild.model.DependencyInsight@d24df30c, com.github.prokod.gradle.crossbuild.model.DependencyInsight@d24df2d1]], [com.github.prokod.gradle.crossbuild.model.DependencyInsight@22186014, []], [com.github.prokod.gradle.crossbuild.model.DependencyInsight@89467852, []], [com.github.prokod.gradle.crossbuild.model.DependencyInsight@89467852, []]]
        at com.github.prokod.gradle.crossbuild.utils.DependencyInsightsTest.When findAllNonMatchingScalaVersionDependenciesWithCounterparts given a dependency set it should return correctly(DependencyInsightsTest.groovy:169)

```

## Fix of the problem
The fix was rather simple. Since regular HashSet in java does not sort the values inside, I changed the collected Set<DependencyInsight> into ```LinkedHashSet<DependencyInsight``` which will automatically sort the inserted strings. Thus, the resulting elements will be compared in a consistent order.

## Result of the fix
The test successed with Nondex runs for 3, 10, and 100 times. It can be safely concluded that the flakiness of this test is fixed

## Test Environment:
```
openjdk version "11.0.20.1"
Gradle 7.2
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```